### PR TITLE
Track content feed if content feed is already loaded.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,13 @@ module.exports = function (feed, res) {
   feed.on('peer-remove', onpeerremove)
 
   if (archive) {
-    archive.on('content', function () {
+    if (archive.content) {
       track(archive.content, 'content')
-    })
+    } else {
+      archive.on('content', function () {
+        track(archive.content, 'content')
+      })
+    }
   }
 
   res.on('close', function () {


### PR DESCRIPTION
In the situation where the content feed is already loaded, the 'content'
event will not be emitted.